### PR TITLE
Update sbatch scripts for sumner2 (memory usage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ This will download the walkthrough data to the current folder.
 > [!IMPORTANT]
 > The walkthrough sample data was not publically available as of 2024/12/20 and may need to be downloaded from the IMPC Cloud. In this case, you can use `wget` to download the `.zip` or use `scp` to copy it from your local machine to Sumner2.
 
-Next, we need to ensure the scripts are executable:
+Next, we need to ensure that all of the scripts are executable:
 ```bash
-cd lama_walkthroughs/
-chmod u+x *.sh 
+chmod u+x *.sbatch
+chmod u+x lama_walkthroughs/*.sh 
 ```
 
 In this repo, we've provided `sbatch` scripts to run each of the parts of the walkthrough on Sumner2 as `sbatch` jobs. These are just regular `bash` scripts with `sbatch` headers defining SLURM job parameters, such as memory usage. You can run them as normal `bash` scripts, but you will need to ensure your interactive session has enough resources, especially memory. Otherwise, it's best to run them using the `sbatch` command, which will use the job parameters from the header.  
@@ -117,7 +117,7 @@ sbatch lama_popavg.sbatch
 Sumner2 will queue up your job and then run it using the parameters from the header. Output files will be stored inside `lama_walkthroughs` and named according to what was specified in the `sbatch` file (by default, `lama_popavg.out` and `lama_popavg.err`).
 
 > [!NOTE]
-> By default, all of the `sbatch` scripts point to the `lama_walkthroughs` directory. To run them on your own data, you can put the data in the template folder in this repository, `lama_workspace`, and then edit the `sbatch` scripts to comment out the line pointing to `lama_walkthroughs` and un-comment the line pointing to `lama_workspace`.
+> By default, all of the `sbatch` scripts point to the `lama_walkthroughs` directory. To run them on your own data, you can put the data in the template folder in this repository, `lama_workspace`, and then edit the `sbatch` scripts to comment out the line pointing to `lama_walkthroughs` and un-comment the line pointing to `lama_workspace`. See also [the next section of this README](#running-an-actual-workflow-on-sumner).
 
 For step 2, use `lama_spatial.sbatch` - it is similar to the previous step, but for parallelization and performance it should be submitted to Sumner2 as an array job using: 
 

--- a/lama_popavg.sbatch
+++ b/lama_popavg.sbatch
@@ -5,8 +5,9 @@
 #SBATCH -t 1-00:00:00
 #SBATCH -N 1
 #SBATCH -c 16
-#SBATCH --mem=20000
+#SBATCH --mem=32000
 
 # Singularity command line options
 module load singularity
-singularity exec LAMA.sif lama_workspace/population_average.sh 2> lama_workspace/lama_popavg.err 1> lama_workspace/lama_popavg.out
+#singularity exec LAMA.sif lama_workspace/population_average.sh 2> lama_workspace/lama_popavg.err 1> lama_workspace/lama_popavg.out
+singularity exec LAMA.sif lama_walkthroughs/population_average.sh 2> lama_walkthroughs/lama_popavg.err 1> lama_walkthroughs/lama_popavg.out

--- a/lama_spatial.sbatch
+++ b/lama_spatial.sbatch
@@ -5,9 +5,9 @@
 #SBATCH -t 1-00:00:00
 #SBATCH -N 1
 #SBATCH -c 16
-#SBATCH --mem=20000
+#SBATCH --mem=48000
 
 # Singularity command line options
 module load singularity
-singularity exec LAMA.sif lama_workspace/spatially_normalise_data.sh 2> lama_workspace/lama_spatial_$SLURM_ARRAY_TASK_ID.err 1> lama_workspace/lama_spatial_$SLURM_ARRAY_TASK_ID.out
-
+#singularity exec LAMA.sif lama_workspace/spatially_normalise_data.sh 2> lama_workspace/lama_spatial_$SLURM_ARRAY_TASK_ID.err 1> lama_workspace/lama_spatial_$SLURM_ARRAY_TASK_ID.out
+singularity exec LAMA.sif lama_walkthroughs/spatially_normalise_data.sh 2> lama_walkthroughs/lama_spatial_$SLURM_ARRAY_TASK_ID.err 1> lama_walkthroughs/lama_spatial_$SLURM_ARRAY_TASK_ID.out

--- a/lama_stats.sbatch
+++ b/lama_stats.sbatch
@@ -4,10 +4,10 @@
 #SBATCH -e lama_stats.err
 #SBATCH -t 1-00:00:00
 #SBATCH -N 1
-#SBATCH -c 16
-#SBATCH --mem=20000
+#SBATCH -c 2
+#SBATCH --mem=120000
 
 # Singularity command line options
 module load singularity
-singularity exec LAMA.sif lama_workspace/stats_with_BH_correction.sh 2> lama_workspace/lama_stats.err 1> lama_workspace/lama_stats.out
-
+#singularity exec LAMA.sif lama_workspace/stats_with_BH_correction.sh 2> lama_workspace/lama_stats.err 1> lama_workspace/lama_stats.out
+singularity exec LAMA.sif lama_walkthroughs/stats_with_BH_correction.sh 2> lama_walkthroughs/lama_stats.err 1> lama_walkthroughs/lama_stats.out


### PR DESCRIPTION
In this PR I updated the sbatch scripts to run on sumner2, mainly fixing the memory requests to account for the fact that sumner2 mercilessly kills jobs that exceed memory requests. All of the scripts will have ~30% headroom now.
Additionally, the stats script only used 1 core throughout, so I lowered the request to 2 cores.

Finally, I added the location of the walkthrough files to make it easy to run, commenting out the local `workspace` folder. To run on own data, the user just needs to change which line is commented out.